### PR TITLE
[MEDIA/SM8150] [R] Remove COPY_HEADERS

### DIFF
--- a/libplatformconfig/Android.mk
+++ b/libplatformconfig/Android.mk
@@ -1,8 +1,7 @@
 LOCAL_PATH := $(call my-dir)
 LOCAL_DIR_PATH:= $(call my-dir)
-include $(CLEAR_VARS)
 
-LOCAL_COPY_HEADERS_TO := libplatformconfig
+include $(CLEAR_VARS)
 
 libplatformconfig-def := \
       -g0 -O3 -fpic \
@@ -14,8 +13,6 @@ libplatformconfig-def := \
     -D_ANDROID_
 
 COMMON_CFLAGS := -O3
-
-include $(BUILD_COPY_HEADERS)
 
 LOCAL_CFLAGS := $(COMMON_CFLAGS) $(libplatformconfig-def)
 

--- a/libstagefrighthw/Android.mk
+++ b/libstagefrighthw/Android.mk
@@ -17,14 +17,6 @@
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
-#===============================================================================
-#             Deploy the headers that can be exposed
-#===============================================================================
-
-LOCAL_COPY_HEADERS_TO   := mm-core/omxcore
-LOCAL_COPY_HEADERS      := QComOMXMetadata.h \
-                           QComOMXPlugin.h
-
 LOCAL_SRC_FILES := \
     QComOMXPlugin.cpp                      \
 

--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -39,39 +39,6 @@ OMXCORE_CFLAGS += -D_ANDROID_O_MR1_DIVX_CHANGES
 endif
 
 #===============================================================================
-#             Deploy the headers that can be exposed
-#===============================================================================
-
-LOCAL_COPY_HEADERS_TO   := mm-core/omxcore
-LOCAL_COPY_HEADERS      := inc/OMX_Audio.h
-LOCAL_COPY_HEADERS      += inc/OMX_Component.h
-LOCAL_COPY_HEADERS      += inc/OMX_ContentPipe.h
-LOCAL_COPY_HEADERS      += inc/OMX_Core.h
-LOCAL_COPY_HEADERS      += inc/OMX_Image.h
-LOCAL_COPY_HEADERS      += inc/OMX_Index.h
-LOCAL_COPY_HEADERS      += inc/OMX_IVCommon.h
-LOCAL_COPY_HEADERS      += inc/OMX_Other.h
-LOCAL_COPY_HEADERS      += inc/OMX_QCOMExtns.h
-LOCAL_COPY_HEADERS      += inc/OMX_Types.h
-LOCAL_COPY_HEADERS      += inc/OMX_Video.h
-LOCAL_COPY_HEADERS      += inc/qc_omx_common.h
-LOCAL_COPY_HEADERS      += inc/qc_omx_component.h
-LOCAL_COPY_HEADERS      += inc/qc_omx_msg.h
-LOCAL_COPY_HEADERS      += inc/QOMX_AudioExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_AudioIndexExtensions.h
-LOCAL_COPY_HEADERS      += inc/OMX_CoreExt.h
-LOCAL_COPY_HEADERS      += inc/QOMX_CoreExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_FileFormatExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_IVCommonExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_SourceExtensions.h
-LOCAL_COPY_HEADERS      += inc/QOMX_VideoExtensions.h
-LOCAL_COPY_HEADERS      += inc/OMX_IndexExt.h
-LOCAL_COPY_HEADERS      += inc/OMX_VideoExt.h
-LOCAL_COPY_HEADERS      += inc/QOMX_StreamingExtensions.h
-LOCAL_COPY_HEADERS      += inc/QCMediaDefs.h
-LOCAL_COPY_HEADERS      += inc/QCMetaData.h
-
-#===============================================================================
 #             LIBRARY for Android apps
 #===============================================================================
 


### PR DESCRIPTION
Nothing seems to depend on these being "exported", and copying headers is disallowed starting from Android R.

@jerpelea is any of your code (camera) depending on these headers? Then we'll turn them into exports.
