### PR TITLE
[DNM] [aosp/LA.UM.8.1.r1] Revert "libc2dcolorconvert: Create system version of the library"

### DIFF
--- a/libc2dcolorconvert/Android.mk
+++ b/libc2dcolorconvert/Android.mk
@@ -1,8 +1,5 @@
 LOCAL_PATH := $(call my-dir)
 
-#======================================================================
-# libc2dcolorconvert - vendor library
-#======================================================================
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := \
@@ -31,36 +28,3 @@ LOCAL_VENDOR_MODULE := true
 
 
 include $(BUILD_SHARED_LIBRARY)
-
-ifeq ($(TARGET_BOARD_AUTO),true)
-#======================================================================
-# libc2dcolorconvert - system library - cannot build if QSSI is enabled
-#======================================================================
-include $(CLEAR_VARS)
-
-LOCAL_SRC_FILES := \
-        C2DColorConverter.cpp
-
-LOCAL_C_INCLUDES := \
-    $(TARGET_OUT_HEADERS)/adreno
-
-
-LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
-
-LOCAL_HEADER_LIBRARIES := \
-        libutils_headers \
-        libhardware_headers \
-        display_intf_headers
-
-LOCAL_SHARED_LIBRARIES := liblog libdl
-
-LOCAL_MODULE_TAGS := optional
-
-LOCAL_MODULE := libc2dcolorconvert_system
-
-LOCAL_ADDITIONAL_DEPENDENCIES := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
-
-include $(BUILD_SHARED_LIBRARY)
-
-endif
-


### PR DESCRIPTION
This way we disable the only use of TARGET_BOARD_AUTO in the HAL.

This reverts commit d0246ae7417d789a39afdf4d1632df8e2c0437ff.