### PR TITLE
[LA.UM.8.1.r1] mm-video-v4l2: venc: Fix the length passed to strncmp

### DIFF
--- a/mm-video-v4l2/vidc/venc/src/video_encoder_device_v4l2.cpp
+++ b/mm-video-v4l2/vidc/venc/src/video_encoder_device_v4l2.cpp
@@ -7272,7 +7272,7 @@ void venc_dev::venc_get_consumer_usage(OMX_U32* usage) {
     }
 
     if (!strncmp(m_platform_name, "trinket", 7) &&
-        !strncmp(m_platform_name, "sm6125", 7)) {
+        !strncmp(m_platform_name, "sm6125", 6)) {
         if (m_sVenc_cfg.input_width < 640 || m_sVenc_cfg.input_height < 480) {
             *usage &= ~GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
         }


### PR DESCRIPTION
Obviously the length of "sm6125" is "6" and not "7".
Fix the copy/paste error.

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>