### PR TITLE
[media] [9.12] Remove unavailable configstore support

### DIFF
--- a/libplatformconfig/Android.mk
+++ b/libplatformconfig/Android.mk
@@ -39,10 +39,10 @@ LOCAL_C_INCLUDES += \
 
 LOCAL_SRC_FILES := PlatformConfig.cpp
 LOCAL_SRC_FILES += ConfigParser.cpp
+LOCAL_SRC_FILES += ConfigStore.cpp
 
 ####################
 ifeq ($(ENABLE_CONFIGSTORE),true)
-LOCAL_SRC_FILES += ConfigStore.cpp
 LOCAL_CFLAGS += -DENABLE_CONFIGSTORE
 LOCAL_SHARED_LIBRARIES += libhidlbase
 LOCAL_SHARED_LIBRARIES += vendor.qti.hardware.capabilityconfigstore@1.0

--- a/libplatformconfig/Android.mk
+++ b/libplatformconfig/Android.mk
@@ -41,7 +41,6 @@ LOCAL_SRC_FILES := PlatformConfig.cpp
 LOCAL_SRC_FILES += ConfigParser.cpp
 
 ####################
-ENABLE_CONFIGSTORE = true
 ifeq ($(ENABLE_CONFIGSTORE),true)
 LOCAL_SRC_FILES += ConfigStore.cpp
 LOCAL_CFLAGS += -DENABLE_CONFIGSTORE


### PR DESCRIPTION
#### libplatformconfig: Do not unconditionally enable configstore support


The vendor.qti.hardware.capabilityconfigstore interface is not available
at build-time (nor at run-time hosted by some ODM blob for that matter):

	vendor/qcom/opensource/media/sm8150/libplatformconfig/Android.mk: error: "libplatformconfig (SHARED_LIBRARIES android-arm64) missing vendor.qti.hardware.capabilityconfigstore@1.0 (SHARED_LIBRARIES android-arm64)"
	vendor/qcom/opensource/media/sm8150/libplatformconfig/Android.mk: error: "libplatformconfig (SHARED_LIBRARIES android-arm) missing vendor.qti.hardware.capabilityconfigstore@1.0 (SHARED_LIBRARIES android-arm)"

Remove forced enablement so that we can enable this from common or
device trees may we ever want to use it.

---

#### libplatformconfig: Always include ConfigStore.cpp

This file provides a fallback if ENABLE_CONFIGSTORE is false. Without
it obvious "undefined symbol" linker errors show up.
