### PR TITLE
[DNM. Needs test][LA.UM.9.12.r1] Replace lito with $(LITO) in conditional checks

### DIFF
--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -16,7 +16,7 @@ endif
 #             Figure out the targets
 #===============================================================================
 
-MPEGH_TARGET_LIST := kona $(KONA) lito bengal
+MPEGH_TARGET_LIST := kona $(KONA) $(LITO) bengal
 ifeq ($(call is-board-platform-in-list, $(MPEGH_TARGET_LIST)), true)
 OMXCORE_CFLAGS += -DAUDIO_MPEGH_ENABLED
 endif
@@ -74,7 +74,7 @@ LOCAL_CFLAGS            := $(OMXCORE_CFLAGS)
 
 LOCAL_SRC_FILES         := src/common/omx_core_cmp.cpp
 LOCAL_SRC_FILES         += src/common/qc_omx_core.c
-ifneq (,$(filter lito bengal kona $(KONA) $(MSMNILE) $(MSMSTEPPE) $(TRINKET) sdm845,$(TARGET_BOARD_PLATFORM)))
+ifneq (,$(filter $(LITO) bengal kona $(KONA) $(MSMNILE) $(MSMSTEPPE) $(TRINKET) sdm845,$(TARGET_BOARD_PLATFORM)))
 LOCAL_SRC_FILES         += src/registry_table_android.c
 else
 LOCAL_SRC_FILES         += src/default/qc_registry_table_android.c
@@ -119,7 +119,7 @@ endif
 
 LOCAL_SRC_FILES         := src/common/omx_core_cmp.cpp
 LOCAL_SRC_FILES         += src/common/qc_omx_core.c
-ifneq (,$(filter lito bengal kona $(KONA) $(MSMNILE) $(MSMSTEPPE) $(TRINKET) sdm845,$(TARGET_BOARD_PLATFORM)))
+ifneq (,$(filter $(LITO) bengal kona $(KONA) $(MSMNILE) $(MSMSTEPPE) $(TRINKET) sdm845,$(TARGET_BOARD_PLATFORM)))
 LOCAL_SRC_FILES         += src/registry_table.c
 else
 LOCAL_SRC_FILES         += src/default/qc_registry_table.c

--- a/product.mk
+++ b/product.mk
@@ -1,4 +1,4 @@
-MSM_VIDC_TARGET_LIST := kona $(KONA) lito bengal
+MSM_VIDC_TARGET_LIST := kona $(KONA) $(LITO) bengal
 
 ifeq ($(call is-board-platform-in-list, $(QCOM_BOARD_PLATFORMS)),true)
 
@@ -25,6 +25,8 @@ PRODUCT_PACKAGES += $(MM_VIDEO)
 
 ifeq ($(TARGET_BOARD_PLATFORM), $(KONA))
 include $(QCOM_MEDIA_ROOT)/conf_files/kona/kona.mk
+else ifeq ($(TARGET_BOARD_PLATFORM, $(LITO))
+include $(QCOM_MEDIA_ROOT)/conf_files/lito/lito.mk
 else
 include $(QCOM_MEDIA_ROOT)/conf_files/$(TARGET_BOARD_PLATFORM)/$(TARGET_BOARD_PLATFORM).mk
 endif


### PR DESCRIPTION
We do not have TARGET_BOARD_PLATFORM set to
lito but as sm6350 (LITO).

This change basically adds support for the newly added
Lena platform based on lito SoC (sm6350).