### PR TITLE
[LA.VENDOR.1.0.r1] Android.mk: Fix build for holi,lahaina,taro targets

### DIFF
--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -16,7 +16,7 @@ endif
 #             Figure out the targets
 #===============================================================================
 
-ifeq ($(filter $(TARGET_BOARD_PLATFORM), kona lito lahaina holi),$(TARGET_BOARD_PLATFORM))
+ifeq ($(filter $(TARGET_BOARD_PLATFORM), kona lito $(LAHAINA) $(HOLI)),$(TARGET_BOARD_PLATFORM))
 OMXCORE_CFLAGS += -D_EN_ADDTNL_CDCS_
 else ifeq ($(filter $(TARGET_BOARD_PLATFORM), $(MSMSTEPPE)),$(TARGET_BOARD_PLATFORM))
 OMXCORE_CFLAGS += -D_STEPPE_
@@ -59,7 +59,7 @@ LOCAL_CFLAGS            := $(OMXCORE_CFLAGS)
 
 LOCAL_SRC_FILES         := src/common/omx_core_cmp.cpp
 LOCAL_SRC_FILES         += src/common/qc_omx_core.c
-ifneq (,$(filter lito bengal kona lahaina holi $(MSMSTEPPE),$(TARGET_BOARD_PLATFORM)))
+ifneq (,$(filter lito bengal kona $(LAHAINA) $(HOLI) $(MSMSTEPPE),$(TARGET_BOARD_PLATFORM)))
 LOCAL_SRC_FILES         += src/registry_table_android.c
 else
 LOCAL_SRC_FILES         += src/default/qc_registry_table_android.c
@@ -100,7 +100,7 @@ endif
 
 LOCAL_SRC_FILES         := src/common/omx_core_cmp.cpp
 LOCAL_SRC_FILES         += src/common/qc_omx_core.c
-ifneq (,$(filter lito bengal kona lahaina holi $(MSMSTEPPE),$(TARGET_BOARD_PLATFORM)))
+ifneq (,$(filter lito bengal kona $(LAHAINA) $(HOLI) $(MSMSTEPPE),$(TARGET_BOARD_PLATFORM)))
 LOCAL_SRC_FILES         += src/$(MM_CORE_TARGET)/registry_table.c
 else
 LOCAL_SRC_FILES         += src/$(MM_CORE_TARGET)/default/qc_registry_table.c

--- a/product.mk
+++ b/product.mk
@@ -13,7 +13,7 @@ PRODUCT_PACKAGES += $(MM_CORE)
 #---------------------------------------------------------------------------------------------------
 # TODO(PC): Override ccodec selection option back to defult (4).
 #           QSSI is forcing this to '1'. Must be reverted
-ifeq ($(call is-board-platform-in-list, taro lahaina holi), true)
+ifeq ($(call is-board-platform-in-list, $(TARO) $(LAHAINA) $(HOLI)), true)
     $(warning "Default Codec2.0 Enabled")
     PRODUCT_PROPERTY_OVERRIDES += debug.stagefright.ccodec=4
 endif


### PR DESCRIPTION
For now this will be used only by the taro target (nagara platform)
but i have included also the holi and lahaina (murray and sagami platforms)
as they will be ported to 5.10 later down the line

Signed-off-by: Martin Botka <martin.botka@somainline.org>