### PR TITLE
[LA.VENDOR.1.0.r1] Forward port LA.UM.9.14.r1 patches

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,5 @@
+ifneq ($(filter 5.10, $(SOMC_KERNEL_VERSION)),)
+
 QCOM_MEDIA_ROOT := $(call my-dir)
 
 #Compile these for all targets under QCOM_BOARD_PLATFORMS list.
@@ -7,3 +9,4 @@ ifeq ($(call is-board-platform-in-list, $(QCOM_BOARD_PLATFORMS)),true)
     include $(QCOM_MEDIA_ROOT)/libplatformconfig/Android.mk
 endif
 
+endif

--- a/libplatformconfig/Android.mk
+++ b/libplatformconfig/Android.mk
@@ -37,7 +37,6 @@ LOCAL_SRC_FILES := PlatformConfig.cpp
 LOCAL_SRC_FILES += ConfigParser.cpp
 
 ####################
-ENABLE_CONFIGSTORE = true
 ifeq ($(ENABLE_CONFIGSTORE),true)
 LOCAL_SRC_FILES += ConfigStore.cpp
 LOCAL_CFLAGS += -DENABLE_CONFIGSTORE

--- a/libplatformconfig/Android.mk
+++ b/libplatformconfig/Android.mk
@@ -35,10 +35,10 @@ LOCAL_C_INCLUDES += \
 
 LOCAL_SRC_FILES := PlatformConfig.cpp
 LOCAL_SRC_FILES += ConfigParser.cpp
+LOCAL_SRC_FILES += ConfigStore.cpp
 
 ####################
 ifeq ($(ENABLE_CONFIGSTORE),true)
-LOCAL_SRC_FILES += ConfigStore.cpp
 LOCAL_CFLAGS += -DENABLE_CONFIGSTORE
 LOCAL_SHARED_LIBRARIES += libhidlbase
 LOCAL_SHARED_LIBRARIES += vendor.qti.hardware.capabilityconfigstore@1.0

--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -33,7 +33,7 @@ endif
 #===============================================================================
 
 LOCAL_C_INCLUDES        := $(LOCAL_PATH)/src/common
-LOCAL_C_INCLUDES        += $(TOP)/hardware/qcom/media/libplatformconfig
+LOCAL_C_INCLUDES        += $(QCOM_MEDIA_ROOT)/libplatformconfig
 
 LOCAL_HEADER_LIBRARIES := \
         libutils_headers \
@@ -74,7 +74,7 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_C_INCLUDES        := $(LOCAL_PATH)/src/common
-LOCAL_C_INCLUDES        += $(TOP)/hardware/qcom/media/libplatformconfig
+LOCAL_C_INCLUDES        += $(QCOM_MEDIA_ROOT)/libplatformconfig
 
 LOCAL_HEADER_LIBRARIES := \
         libutils_headers \


### PR DESCRIPTION
These patches are needed for building.

1 was excluded since qcom is updating their stuff as well (Copy headers)